### PR TITLE
refactor: fetch 공통함수 구현

### DIFF
--- a/src/components/GymListBanner.tsx
+++ b/src/components/GymListBanner.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { GymSampleInfo } from "../pages/home";
 import { Dispatch, MouseEventHandler, SetStateAction } from "react";
 import router from "next/router";
+import { requestData } from "@/service/api";
 
 const sampleList = [
   {
@@ -26,11 +27,17 @@ const GymListBanner = ({
   setGymList,
   searchWord,
 }: GymListBannerProps) => {
-  const getData = async (sort: string | null) => {
-    const res = await fetch(`http://localhost:3000/gyms?s=${sort}`);
-    const data = await res.json();
-    setGymList(data);
-  };
+  // const getData = async (sort: string | null) => {
+  //   const res = await fetch(`http://localhost:3000/gyms?s=${sort}`);
+  //   const data = await res.json();
+  //   setGymList(data);
+  // };
+
+  requestData({
+    option: "GET",
+    url: `/gyms?s=인기순`,
+    onSuccess: (data) => setGymList(data),
+  });
   const sortingType = ["인기순", "최신순", "거리순"];
 
   const handleButtonClick: MouseEventHandler<HTMLButtonElement> = (event) => {

--- a/src/components/settings/MyBookmark.tsx
+++ b/src/components/settings/MyBookmark.tsx
@@ -4,30 +4,37 @@ import { GymSampleInfo } from "@/pages/home";
 import { useEffect, useState } from "react";
 import { sampleGyms } from "../LazyLoadingItems";
 import { useSession } from "next-auth/react";
+import { requestData } from "@/service/api";
 
 const MyBookmark = () => {
   const { data: session, status } = useSession();
   const [items, setItems] = useState<GymSampleInfo[]>();
 
   useEffect(() => {
-    const fetchBookmarksFromServer = async () => {
-      try {
-        // const response = await fetch(`/api/bookmarks/`, {
-        //   method: "GET",
-        //   headers: {
-        //     "Content-Type": "application/json",
-        //     Authorization: { sessionId },
-        //   },
-        // });
-        // const data = await response.json();
-        const data = sampleGyms;
-        setItems(data);
-      } catch (error) {
-        console.error("내 북마크 GET 에러", error);
-      }
-    };
+    // const fetchBookmarksFromServer = async () => {
+    //   try {
+    // const response = await fetch(`/api/bookmarks/`, {
+    //   method: "GET",
+    //   headers: {
+    //     "Content-Type": "application/json",
+    //     Authorization: { sessionId },
+    //   },
+    // });
+    // const data = await response.json();
+    //     const data = sampleGyms;
+    //     setItems(data);
+    //   } catch (error) {
+    //     console.error("내 북마크 GET 에러", error);
+    //   }
+    // };
     if (session) {
-      fetchBookmarksFromServer();
+      requestData({
+        option: "GET",
+        url: "/api/bookmarks",
+        // sessionId:{session.user.sessionId}
+        onSuccess: (data) => setItems(data),
+      });
+      // fetchBookmarksFromServer();
     }
   }, [session]);
 

--- a/src/components/settings/Mypage.tsx
+++ b/src/components/settings/Mypage.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { styled } from "styled-components";
 import { useRouter } from "next/router";
 import React from "react";
+import { requestData } from "@/service/api";
 
 const Mypage = () => {
   // 현재는 세션이 있을때 메이페이지가 보이지만 추후 백엔드 요청시 정보가 있을때만 표시
@@ -94,15 +95,21 @@ const Mypage = () => {
       nickname: { label: nickname, type: "nickname" },
     };
 
-    const response = await fetch("http://localhost:3000/members/update", {
-      method: "UPDATE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(credentials),
+    requestData({
+      option: "POST",
+      url: "/members/update",
+      onSuccess: () => router.reload(),
     });
+    // const response = await fetch("http://localhost:3000/members/update", {
+    //   method: "UPDATE",
+    //   headers: { "Content-Type": "application/json" },
+    //   body: JSON.stringify(credentials),
+    // });
 
     // const data = await response.json();
 
-    router.reload();
+    // router.reload();
+
     // if (data.ok) {
     //   //정상적 업데이트 => 현재페이지 재표시
     //   router.reload();

--- a/src/constants/service/type.ts
+++ b/src/constants/service/type.ts
@@ -16,13 +16,13 @@ export interface RequestProps {
 }
 
 export interface GetProps {
-  url: string;
+  absoluteUrl: string;
   sessionId?: string;
   onSuccess?: (data: any) => void;
 }
 
 export interface PostProps {
-  url: string;
+  absoluteUrl: string;
   data: any;
   sessionId?: string;
   onSuccess?: (data: any) => void;

--- a/src/constants/service/type.ts
+++ b/src/constants/service/type.ts
@@ -1,0 +1,29 @@
+const requestOptions = {
+  GET: "GET",
+  POST: "POST",
+  DELETE: "DELETE",
+} as const;
+
+type Option = (typeof requestOptions)[keyof typeof requestOptions];
+
+// 데이터 타입 정의
+export interface RequestProps {
+  option: Option;
+  url: string;
+  sessionId?: string;
+  data?: any;
+  onSuccess?: (data: any) => void;
+}
+
+export interface GetProps {
+  url: string;
+  sessionId?: string;
+  onSuccess?: (data: any) => void;
+}
+
+export interface PostProps {
+  url: string;
+  data: any;
+  sessionId?: string;
+  onSuccess?: (data: any) => void;
+}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
-import { useEffect, useState } from "react";
+import { SetStateAction, useEffect, useState } from "react";
 import GymListBanner from "../../components/GymListBanner";
 import SearchBanner from "./searchBanner";
+import { requestData } from "@/service/api";
 
 const sampleGyms: GymSampleInfo[] = [
   {
@@ -72,11 +73,16 @@ export interface GymSampleInfo {
 }
 
 const Home = () => {
-  const getData = async () => {
-    const res = await fetch("http://localhost:3000/gyms");
-    const data = await res.json();
-    setGymLists(data);
-  };
+  requestData({
+    option: "GET",
+    url: "/gyms",
+    onSuccess: (input) => setGymLists(input),
+  });
+  // const getData = async () => {
+  //   const res = await fetch("http://localhost:3000/gyms");
+  //   const data = await res.json();
+  //   setGymLists(data);
+  // };
   const [gymLists, setGymLists] = useState<GymSampleInfo[]>(sampleGyms); //sampleGyms
 
   // useEffect(() => {

--- a/src/pages/home/searchBanner.tsx
+++ b/src/pages/home/searchBanner.tsx
@@ -6,6 +6,7 @@ import { Dispatch, FormEventHandler, SetStateAction } from "react";
 import router from "next/router";
 import Image from "next/image";
 import img from "../../../public/magnifier.png";
+import { requestData } from "@/service/api";
 
 const sampleAddress = [
   { id: 1, info: "잠실" },
@@ -31,11 +32,16 @@ interface SearchBannerProps {
 }
 
 const SearchBanner = ({ setGymList }: SearchBannerProps) => {
-  const getData = async (input: string | null) => {
-    const res = await fetch(`http://localhost:3000/search?q={input}`);
-    const data = await res.json();
-    setGymList(data);
-  };
+  requestData({
+    option: "GET",
+    url: `/search?q={input}`,
+    onSuccess: (data) => setGymList(data),
+  });
+  // const getData = async (input: string | null) => {
+  //   const res = await fetch(`http://localhost:3000/search?q={input}`);
+  //   const data = await res.json();
+  //   setGymList(data);
+  // };
 
   const handleGymList = (event: {
     target: any;

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -130,7 +130,7 @@ const Join = () => {
       option: "POST",
       url: "/members/join",
       data: credentials,
-      onSuccess: onSuccess,
+      onSuccess,
     });
 
     // const response = await fetch("http://localhost:3000/members/join", {

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -97,6 +97,12 @@ const Join = () => {
       setNicknameMessage("닉네임은 3자이상이어야 합니다.");
       setIsNicknameValid(false);
     } else {
+      // requestData({
+      //   option: "GET",
+      //   url: "/members/emailCheck",
+      //   data: email,
+      //   // onSuccess,
+      // });
       // const res = await fetch(`http://localhost:3000/members/emailCheck`);
       // const data = await res.json();
 

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -1,4 +1,5 @@
 import InputWithTitle from "@/components/InputWithTitle";
+import { requestData } from "@/service/api";
 import { useState } from "react";
 import styled from "styled-components";
 
@@ -121,24 +122,35 @@ const Join = () => {
       nickname: { label: nickname, type: "nickname" },
     };
 
-    const response = await fetch("http://localhost:3000/members/join", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(credentials),
+    const onSuccess = () => {
+      console.log("onSuccess");
+    };
+
+    requestData({
+      option: "POST",
+      url: "/members/join",
+      data: credentials,
+      onSuccess: onSuccess,
     });
 
-    const data = await response.json();
+    // const response = await fetch("http://localhost:3000/members/join", {
+    //   method: "POST",
+    //   headers: { "Content-Type": "application/json" },
+    //   body: JSON.stringify(credentials),
+    // });
 
-    if (data.ok) {
-      //정상적 회원가입
-      // return {
-      //   name: data.name,
-      //   email: data.email,
-      //   token: data.token,
-      // };
-    } else {
-      return null as any;
-    }
+    // const data = await response.json();
+
+    // if (data.ok) {
+    //정상적 회원가입
+    // return {
+    //   name: data.name,
+    //   email: data.email,
+    //   token: data.token,
+    // };
+    // } else {
+    // return null as any;
+    // }
   };
 
   return (

--- a/src/service/api/index.ts
+++ b/src/service/api/index.ts
@@ -9,9 +9,9 @@ export const requestData = async ({
 }: RequestProps) => {
   switch (option) {
     case "GET":
-      return () => getData({ url, sessionId, onSuccess });
+      return getData({ url, sessionId, onSuccess });
     case "POST":
-      return () => postData({ url, data, sessionId, onSuccess });
+      return postData({ url, data, sessionId, onSuccess });
     // POST로 DELETE를 대체가능
     // case "DELETE":
     //   break;

--- a/src/service/api/index.ts
+++ b/src/service/api/index.ts
@@ -1,4 +1,4 @@
-import { GetProps, PostProps, RequestProps } from "@/constants/service/type";
+import { RequestProps, GetProps, PostProps } from "@/constants/service/type";
 
 export const requestData = async ({
   option,
@@ -7,11 +7,13 @@ export const requestData = async ({
   data,
   onSuccess, // 성공 후 처리
 }: RequestProps) => {
+  const absoluteUrl = "http://localhost:3000" + url;
+
   switch (option) {
     case "GET":
-      return getData({ url, sessionId, onSuccess });
+      return getData({ absoluteUrl, sessionId, onSuccess });
     case "POST":
-      return postData({ url, data, sessionId, onSuccess });
+      return postData({ absoluteUrl, data, sessionId, onSuccess });
     // POST로 DELETE를 대체가능
     // case "DELETE":
     //   break;
@@ -20,8 +22,8 @@ export const requestData = async ({
   }
 };
 
-const getData = ({ url, sessionId, onSuccess }: GetProps) => {
-  fetch(url, {
+const getData = ({ absoluteUrl, sessionId, onSuccess }: GetProps) => {
+  fetch(absoluteUrl, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -45,8 +47,8 @@ const getData = ({ url, sessionId, onSuccess }: GetProps) => {
     .catch((error) => console.log(error.message));
 };
 
-const postData = ({ url, data, sessionId, onSuccess }: PostProps) => {
-  fetch(url, {
+const postData = ({ absoluteUrl, data, sessionId, onSuccess }: PostProps) => {
+  fetch(absoluteUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -65,7 +67,7 @@ const postData = ({ url, data, sessionId, onSuccess }: PostProps) => {
       if (onSuccess) {
         return onSuccess(result);
       }
-      return result;
+      return;
     })
     .catch((error) => console.log(error.message));
 };

--- a/src/service/api/index.ts
+++ b/src/service/api/index.ts
@@ -1,0 +1,71 @@
+import { GetProps, PostProps, RequestProps } from "@/constants/service/type";
+
+export const requestData = async ({
+  option,
+  url,
+  sessionId,
+  data,
+  onSuccess, // 성공 후 처리
+}: RequestProps) => {
+  switch (option) {
+    case "GET":
+      return () => getData({ url, sessionId, onSuccess });
+    case "POST":
+      return () => postData({ url, data, sessionId, onSuccess });
+    // POST로 DELETE를 대체가능
+    // case "DELETE":
+    //   break;
+    default:
+      console.log("잘못된 옵션 설정");
+  }
+};
+
+const getData = ({ url, sessionId, onSuccess }: GetProps) => {
+  fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `${sessionId}`,
+    },
+  })
+    .then((response) => {
+      if (!response.ok) {
+        // 404, 500...등의 에러
+        throw new Error(`${response.status} 에러 발생`);
+      }
+      // 실제 데이터 반환
+      return response.json;
+    })
+    .then((result) => {
+      if (onSuccess) {
+        return onSuccess(result);
+      }
+      return result;
+    })
+    .catch((error) => console.log(error.message));
+};
+
+const postData = ({ url, data, sessionId, onSuccess }: PostProps) => {
+  fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `${sessionId}`,
+    },
+    body: JSON.stringify(data),
+  })
+    .then((response) => {
+      if (!response.ok) {
+        // 404, 500...등의 에러
+        throw new Error(`${response.status} 에러 발생`);
+      }
+      return response.json;
+    })
+    .then((result) => {
+      if (onSuccess) {
+        return onSuccess(result);
+      }
+      return result;
+    })
+    .catch((error) => console.log(error.message));
+};


### PR DESCRIPTION
fetch 관련해서 공통함수를 만들었습니다.
해당함수는 [src/service/api/index.ts](https://github.com/climbing-project/climbing-frontend/compare/refactor/api?expand=1#diff-760440fd8a8b47ca48136968a620e9f5d61a4b7967c9451b24906dd543d09f02) 여기에 있습니다

<파라미터>
  option: Option;
  url: string;
  sessionId?: string;
  data?: any;
  onSuccess?: (data: any) => void;

* option("GET","POST") 과 url(상대url)은 필수로 넣어주세요
data는 post시 넣어주시면 되고,
onSuccess는 성공후에 다른페이지로 라우팅하거나 usestate 쓰는둥.. 성공후 필요한 작업을 넣어주세요


* 사용예시
  requestData({
    option: "GET",
    url: "/gyms",
    onSuccess: (input) => setGymLists(input),
  });

cf> 원래는 ("GET","/gyms").. 이렇게 key값 없이 바로 호출되게 하려했지만,,
그렇게 하면 안쓰는 파라미터도 undefined 아규먼트로 꼭 넣어줘야되더라구요..ㅠㅠ
그래서 아쉽지만 이렇게 쓰게되었습니다..

나중에 백엔드 서버 쓸수있으면 그때 확인하면서 천천히 적용하면 될거같아용

---

이번주에 너무 코딩에 시간을 못썻네요,,  주요기능이 끝났다생각되서 스스로 해이헤진거 같아요.
다음주부턴 미리 디코에 제가 할것들 상세히 공지하고 코딩하는 식으로 하겠습니다..
제가 필요해서 하는거라 승아님께서는 안하셔도됩니다..혹시 부담가지실까봐 말씀드립니다..